### PR TITLE
feat: add language registry with AST/text classification

### DIFF
--- a/src/languages.test.ts
+++ b/src/languages.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LANGUAGE_MAP,
+  AST_LANGUAGES,
+  TEXT_LANGUAGES,
+  getLanguage,
+  getSupportedExtensions,
+} from './languages.ts';
+
+describe('languages', () => {
+  describe('getLanguage', () => {
+    it('returns correct entry for AST languages', () => {
+      expect(getLanguage('src/index.ts')?.name).toBe('typescript');
+      expect(getLanguage('app.py')?.name).toBe('python');
+      expect(getLanguage('main.rs')?.name).toBe('rust');
+    });
+
+    it('returns correct entry for text languages', () => {
+      expect(getLanguage('README.md')?.name).toBe('markdown');
+      expect(getLanguage('data.json')?.name).toBe('json');
+      expect(getLanguage('config.yaml')?.name).toBe('yaml');
+    });
+
+    it('returns undefined for unknown extensions', () => {
+      expect(getLanguage('image.png')).toBeUndefined();
+      expect(getLanguage('binary.exe')).toBeUndefined();
+    });
+
+    it('handles nested paths', () => {
+      expect(getLanguage('src/utils/helper.ts')?.name).toBe('typescript');
+    });
+  });
+
+  describe('AST_LANGUAGES', () => {
+    it('contains expected languages', () => {
+      expect(AST_LANGUAGES.has('typescript')).toBe(true);
+      expect(AST_LANGUAGES.has('python')).toBe(true);
+      expect(AST_LANGUAGES.has('rust')).toBe(true);
+    });
+
+    it('does not contain text languages', () => {
+      expect(AST_LANGUAGES.has('markdown')).toBe(false);
+      expect(AST_LANGUAGES.has('json')).toBe(false);
+    });
+  });
+
+  describe('TEXT_LANGUAGES', () => {
+    it('contains expected languages', () => {
+      expect(TEXT_LANGUAGES.has('markdown')).toBe(true);
+      expect(TEXT_LANGUAGES.has('json')).toBe(true);
+      expect(TEXT_LANGUAGES.has('yaml')).toBe(true);
+    });
+  });
+
+  describe('no overlap between AST and TEXT', () => {
+    it('sets have zero intersection', () => {
+      for (const lang of AST_LANGUAGES) {
+        expect(TEXT_LANGUAGES.has(lang)).toBe(false);
+      }
+    });
+  });
+
+  describe('getSupportedExtensions', () => {
+    it('includes key extensions', () => {
+      const exts = getSupportedExtensions();
+      expect(exts).toContain('.ts');
+      expect(exts).toContain('.py');
+      expect(exts).toContain('.md');
+      expect(exts).toContain('.json');
+    });
+  });
+
+  describe('LANGUAGE_MAP', () => {
+    it('maps all extensions from each language entry', () => {
+      expect(LANGUAGE_MAP.get('.tsx')?.name).toBe('typescript');
+      expect(LANGUAGE_MAP.get('.jsx')?.name).toBe('javascript');
+      expect(LANGUAGE_MAP.get('.yml')?.name).toBe('yaml');
+      expect(LANGUAGE_MAP.get('.gql')?.name).toBe('graphql');
+    });
+  });
+});

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -1,0 +1,46 @@
+import path from 'node:path';
+
+interface LanguageEntry {
+  name: string;
+  type: 'ast' | 'text';
+  extensions: string[];
+}
+
+const LANGUAGES: LanguageEntry[] = [
+  { name: 'typescript', type: 'ast', extensions: ['.ts', '.tsx'] },
+  { name: 'javascript', type: 'ast', extensions: ['.js', '.jsx', '.mjs', '.cjs'] },
+  { name: 'python', type: 'ast', extensions: ['.py'] },
+  { name: 'rust', type: 'ast', extensions: ['.rs'] },
+  { name: 'go', type: 'ast', extensions: ['.go'] },
+  { name: 'css', type: 'ast', extensions: ['.css'] },
+  { name: 'graphql', type: 'ast', extensions: ['.graphql', '.gql'] },
+  { name: 'markdown', type: 'text', extensions: ['.md', '.mdx'] },
+  { name: 'json', type: 'text', extensions: ['.json'] },
+  { name: 'yaml', type: 'text', extensions: ['.yaml', '.yml'] },
+  { name: 'toml', type: 'text', extensions: ['.toml'] },
+  { name: 'sql', type: 'text', extensions: ['.sql'] },
+];
+
+const LANGUAGE_MAP = new Map<string, LanguageEntry>();
+
+for (const entry of LANGUAGES) {
+  for (const extension of entry.extensions) {
+    LANGUAGE_MAP.set(extension, entry);
+  }
+}
+
+const AST_LANGUAGES = new Set(LANGUAGES.filter((l) => l.type === 'ast').map((l) => l.name));
+
+const TEXT_LANGUAGES = new Set(LANGUAGES.filter((l) => l.type === 'text').map((l) => l.name));
+
+function getLanguage(filepath: string): LanguageEntry | undefined {
+  const extension = path.extname(filepath);
+  return LANGUAGE_MAP.get(extension);
+}
+
+function getSupportedExtensions(): string[] {
+  return [...LANGUAGE_MAP.keys()];
+}
+
+export { LANGUAGE_MAP, AST_LANGUAGES, TEXT_LANGUAGES, getLanguage, getSupportedExtensions };
+export type { LanguageEntry };


### PR DESCRIPTION
## Summary
- Adds `src/languages.ts` — single source of truth mapping file extensions → language info & chunking strategy (AST vs text)
- Exports `LANGUAGE_MAP`, `AST_LANGUAGES`, `TEXT_LANGUAGES`, `getLanguage()`, `getSupportedExtensions()`
- Full test coverage (10 tests) in `src/languages.test.ts`

Closes #1

## Supported Languages
| Type | Languages |
|------|-----------|
| AST | TypeScript, JavaScript, Python, Rust, Go, CSS, GraphQL |
| Text | Markdown, JSON, YAML, TOML, SQL |

## Test plan
- [x] `getLanguage()` returns correct entry for AST and text languages
- [x] `getLanguage()` returns undefined for unknown extensions
- [x] `AST_LANGUAGES` and `TEXT_LANGUAGES` have zero overlap
- [x] `getSupportedExtensions()` returns all mapped extensions
- [x] All CI checks pass (format, lint, typecheck, test, build)