### PR TITLE
feat: file walker with git ls-files, fast-glob fallback, and binary check (#2)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,9 @@ export default tseslint.config(
   {
     languageOptions: {
       parserOptions: {
-        projectService: true,
+        projectService: {
+          allowDefaultProject: ['*.config.ts'],
+        },
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,13 @@
-console.log('hey there');
+import { walkFiles } from './walker.ts';
+
+async function main(): Promise<void> {
+  const cwd = process.cwd();
+  console.log(`walking files in: ${cwd}`);
+  const files = await walkFiles(cwd);
+  for (const file of files) {
+    console.log('file: ', file);
+  }
+  console.log(`Total files: ${files.length}`);
+}
+
+main();

--- a/src/walker.test.ts
+++ b/src/walker.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { isBinary, walkFiles } from './walker.ts';
+
+const execFileAsync = promisify(execFile);
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await mkdtemp(path.join(tmpdir(), 'walker-test-'));
+});
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true });
+});
+
+async function initGitRepo(dir: string): Promise<void> {
+  await execFileAsync('git', ['init'], { cwd: dir });
+  await execFileAsync('git', ['add', '.'], { cwd: dir });
+}
+
+describe('isBinary', () => {
+  it('detects binary files', async () => {
+    const file = path.join(testDir, 'binary.ts');
+    await writeFile(file, Buffer.from([0x00, 0x01, 0x02, 0x03]));
+    expect(await isBinary(file)).toBe(true);
+  });
+
+  it('passes text files', async () => {
+    const file = path.join(testDir, 'text.ts');
+    await writeFile(file, 'const x = 1;');
+    expect(await isBinary(file)).toBe(false);
+  });
+
+  it('treats empty files as non-binary', async () => {
+    const file = path.join(testDir, 'empty.ts');
+    await writeFile(file, '');
+    expect(await isBinary(file)).toBe(false);
+  });
+
+  it('returns true for unreadable paths', async () => {
+    expect(await isBinary(path.join(testDir, 'nope.ts'))).toBe(true);
+  });
+});
+
+describe('walkFiles', () => {
+  it('finds supported files in a git repo', async () => {
+    await writeFile(path.join(testDir, 'index.ts'), 'const x = 1;');
+    await writeFile(path.join(testDir, 'app.py'), 'x = 1');
+    await writeFile(path.join(testDir, 'README.md'), '# Hello');
+    await initGitRepo(testDir);
+
+    const files = await walkFiles(testDir);
+    const names = files.map((f) => path.basename(f));
+
+    expect(names).toContain('index.ts');
+    expect(names).toContain('app.py');
+    expect(names).toContain('README.md');
+  });
+
+  it('skips unsupported extensions', async () => {
+    await writeFile(path.join(testDir, 'index.ts'), 'const x = 1;');
+    await writeFile(path.join(testDir, 'photo.png'), 'fakepng');
+    await writeFile(path.join(testDir, 'app.exe'), 'fakeexe');
+    await initGitRepo(testDir);
+
+    const files = await walkFiles(testDir);
+    const names = files.map((f) => path.basename(f));
+
+    expect(names).toContain('index.ts');
+    expect(names).not.toContain('photo.png');
+    expect(names).not.toContain('app.exe');
+  });
+
+  it('skips files with no extension', async () => {
+    await writeFile(path.join(testDir, 'Makefile'), 'all: build');
+    await writeFile(path.join(testDir, 'Dockerfile'), 'FROM node');
+    await writeFile(path.join(testDir, 'index.ts'), 'const x = 1;');
+    await initGitRepo(testDir);
+
+    const files = await walkFiles(testDir);
+    const names = files.map((f) => path.basename(f));
+
+    expect(names).toContain('index.ts');
+    expect(names).not.toContain('Makefile');
+    expect(names).not.toContain('Dockerfile');
+  });
+
+  it('skips binary files with supported extensions', async () => {
+    await writeFile(path.join(testDir, 'corrupt.ts'), Buffer.from([0x00, 0x01, 0x02]));
+    await writeFile(path.join(testDir, 'good.ts'), 'const x = 1;');
+    await initGitRepo(testDir);
+
+    const files = await walkFiles(testDir);
+    const names = files.map((f) => path.basename(f));
+
+    expect(names).toContain('good.ts');
+    expect(names).not.toContain('corrupt.ts');
+  });
+
+  it('returns absolute paths', async () => {
+    await writeFile(path.join(testDir, 'index.ts'), 'const x = 1;');
+    await initGitRepo(testDir);
+
+    const files = await walkFiles(testDir);
+
+    for (const file of files) {
+      expect(path.isAbsolute(file)).toBe(true);
+    }
+  });
+
+  it('uses fast-glob fallback in non-git directories', async () => {
+    await writeFile(path.join(testDir, 'index.ts'), 'const x = 1;');
+    await writeFile(path.join(testDir, 'app.py'), 'x = 1');
+
+    const files = await walkFiles(testDir);
+    const names = files.map((f) => path.basename(f));
+
+    expect(names).toContain('index.ts');
+    expect(names).toContain('app.py');
+  });
+
+  it('returns empty array for empty directory', async () => {
+    await initGitRepo(testDir);
+    const files = await walkFiles(testDir);
+    expect(files).toEqual([]);
+  });
+
+  it('finds files in subdirectories', async () => {
+    await mkdir(path.join(testDir, 'src', 'utils'), { recursive: true });
+    await writeFile(path.join(testDir, 'src', 'index.ts'), 'const x = 1;');
+    await writeFile(path.join(testDir, 'src', 'utils', 'helper.ts'), 'export const y = 2;');
+    await initGitRepo(testDir);
+
+    const files = await walkFiles(testDir);
+    const names = files.map((f) => path.basename(f));
+
+    expect(names).toContain('index.ts');
+    expect(names).toContain('helper.ts');
+    expect(files.length).toBe(2);
+  });
+
+  it('handles many files concurrently', async () => {
+    for (let i = 0; i < 25; i++) {
+      await writeFile(path.join(testDir, `file${i}.ts`), `const x${i} = ${i};`);
+    }
+    await initGitRepo(testDir);
+
+    const files = await walkFiles(testDir);
+    expect(files.length).toBe(25);
+  });
+});

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -1,0 +1,74 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import fg from 'fast-glob';
+import { getLanguage } from './languages.ts';
+
+const execFileAsync = promisify(execFile);
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+const FALLBACK_IGNORE = [
+  '**/node_modules/**',
+  '**/.git/**',
+  '**/dist/**',
+  '**/build/**',
+  '**/.next/**',
+  '**/coverage/**',
+  '**/.cache/**',
+  '**/vendor/**',
+  '**/__pycache__/**',
+  '**/target/**',
+];
+
+async function isBinary(filePath: string): Promise<boolean> {
+  let handle: fs.FileHandle | null = null;
+  try {
+    handle = await fs.open(filePath, 'r');
+    const buffer = Buffer.alloc(512);
+    const { bytesRead } = await handle.read(buffer, 0, 512, 0);
+    if (bytesRead === 0) return false;
+    return buffer.subarray(0, bytesRead).includes(0x00);
+  } catch {
+    return true;
+  } finally {
+    await handle?.close();
+  }
+}
+
+async function discoverFiles(rootDir: string): Promise<string[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['ls-files', '--cached', '--others', '--exclude-standard'],
+      { cwd: rootDir, maxBuffer: MAX_BUFFER },
+    );
+    return stdout.split('\n').filter(Boolean);
+  } catch {
+    const files = await fg('**/*', {
+      cwd: rootDir,
+      ignore: FALLBACK_IGNORE,
+      dot: false,
+      absolute: false,
+    });
+    return files;
+  }
+}
+
+async function walkFiles(rootDir: string): Promise<string[]> {
+  const resolvedRoot = path.resolve(rootDir);
+  const relativePaths = await discoverFiles(resolvedRoot);
+  const supported = relativePaths.filter((file) => getLanguage(file) !== undefined);
+
+  const results = await Promise.all(
+    supported.map(async (file) => {
+      const abs = path.resolve(resolvedRoot, file);
+      const binary = await isBinary(abs);
+      return binary ? null : abs;
+    }),
+  );
+
+  return results.filter((f): f is string => f !== null);
+}
+
+export { walkFiles, isBinary };


### PR DESCRIPTION
## Summary
- Adds `src/walker.ts` — discovers all indexable files in a codebase
- Three-layer filtering: git ls-files → LANGUAGE_MAP extension check → binary null-byte check
- `fast-glob` fallback for non-git directories
- Concurrent binary checks via `Promise.all`
- Updates `src/index.ts` to wire walker for manual testing
- 13 tests covering happy path, edge cases, error paths, and concurrency

Closes #2

## Design
| Layer | What it filters |
|-------|----------------|
| `git ls-files` | .gitignore'd files (node_modules, dist, .env, etc.) |
| `LANGUAGE_MAP` | Unsupported extensions (.png, .exe, Makefile, etc.) |
| `isBinary()` | Binary files with supported extensions |

## Test plan
- [x] `isBinary` detects binary files / passes text files / handles empty files / handles unreadable paths
- [x] `walkFiles` finds supported files in git repos
- [x] `walkFiles` skips unsupported extensions, extensionless files, binary files
- [x] `walkFiles` returns absolute paths
- [x] `walkFiles` falls back to fast-glob in non-git directories
- [x] `walkFiles` handles empty directories and subdirectories
- [x] `walkFiles` handles 25 concurrent files
- [x] All CI checks pass (format, lint, typecheck, 33 tests, build)