### PR TITLE
chore: add pino structured logger (#16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "commander": "^14.0.3",
         "dotenv": "^16.6.1",
         "fast-glob": "^3.3.3",
+        "pino": "^10.3.1",
+        "pino-pretty": "^13.1.3",
         "tree-sitter": "^0.21.1",
         "tree-sitter-css": "^0.21.1",
         "tree-sitter-go": "^0.21.2",
@@ -27,6 +29,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^22.19.15",
+        "@types/pino-pretty": "^4.7.5",
         "@vitest/coverage-v8": "^4.1.0",
         "eslint": "^10.0.3",
         "eslint-config-prettier": "^10.1.8",
@@ -856,6 +859,12 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
@@ -1183,6 +1192,50 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pino": {
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/@types/pino/-/pino-6.3.12.tgz",
+      "integrity": "sha512-dsLRTq8/4UtVSpJgl9aeqHvbh6pzdmjYD3C092SYgLD2TyoCqHpTJk6vp8DvCTGGc7iowZ2MoiYiVUUCcu7muw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pino-pretty": "*",
+        "@types/pino-std-serializers": "*",
+        "sonic-boom": "^2.1.0"
+      }
+    },
+    "node_modules/@types/pino-pretty": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/@types/pino-pretty/-/pino-pretty-4.7.5.tgz",
+      "integrity": "sha512-rfHe6VIknk14DymxGqc9maGsRe8/HQSvM2u46EAz2XrS92qsAJnW16dpdFejBuZKD8cRJX6Aw6uVZqIQctMpAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/pino": "6.3"
+      }
+    },
+    "node_modules/@types/pino-std-serializers": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/pino-std-serializers/-/pino-std-serializers-2.4.1.tgz",
+      "integrity": "sha512-17XcksO47M24IVTVKPeAByWUd3Oez7EbIjXpSbzMPhXVzgjGtrOa49gKBwxH9hb8dKv58OelsWQ+A1G1l9S3wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/pino/node_modules/sonic-boom": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1621,6 +1674,15 @@
         "js-tokens": "^10.0.0"
       }
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1666,6 +1728,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "license": "MIT"
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -1695,6 +1763,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1742,6 +1819,15 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-module-lexer": {
@@ -2007,6 +2093,12 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-copy": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
+      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2042,6 +2134,12 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -2166,6 +2264,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2267,6 +2371,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/js-tokens": {
@@ -2674,6 +2787,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2737,6 +2859,24 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2834,6 +2974,67 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-13.1.3.tgz",
+      "integrity": "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==",
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-copy": "^4.0.0",
+        "fast-safe-stringify": "^2.1.1",
+        "help-me": "^5.0.0",
+        "joycon": "^3.1.1",
+        "minimist": "^1.2.6",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pump": "^3.0.0",
+        "secure-json-parse": "^4.0.0",
+        "sonic-boom": "^4.0.1",
+        "strip-json-comments": "^5.0.2"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -2889,6 +3090,32 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2918,6 +3145,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -2996,6 +3238,31 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -3039,6 +3306,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3047,6 +3323,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -3063,6 +3348,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-json-comments": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
+      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3074,6 +3371,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tinybench": {
@@ -3658,6 +3967,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "commander": "^14.0.3",
     "dotenv": "^16.6.1",
     "fast-glob": "^3.3.3",
+    "pino": "^10.3.1",
+    "pino-pretty": "^13.1.3",
     "tree-sitter": "^0.21.1",
     "tree-sitter-css": "^0.21.1",
     "tree-sitter-go": "^0.21.2",
@@ -50,6 +52,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^22.19.15",
+    "@types/pino-pretty": "^4.7.5",
     "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",

--- a/src/chunker/ast.ts
+++ b/src/chunker/ast.ts
@@ -7,6 +7,9 @@ import Go from 'tree-sitter-go';
 import CSS from 'tree-sitter-css';
 import type { Chunk } from './types.ts';
 import { fallbackChunk } from './fallback.ts';
+import { createLogger } from '../utils/logger.ts';
+
+const log = createLogger('chunker');
 
 // --- Parser cache (one parser per language, reused) ---
 
@@ -67,7 +70,7 @@ const AST_NODE_TYPES: Record<string, Set<string>> = {
 function chunkAST(source: string, filePath: string, language: string): Chunk[] {
   const parser = getParser(language);
   if (!parser) {
-    console.warn(`[chunker] No tree-sitter grammar for "${language}", using fallback: ${filePath}`);
+    log.warn(`No tree-sitter grammar for "${language}", using fallback: ${filePath}`);
     return [fallbackChunk(source, filePath, language)];
   }
 
@@ -83,8 +86,8 @@ function chunkAST(source: string, filePath: string, language: string): Chunk[] {
   try {
     tree = parser.parse(source);
   } catch (err: unknown) {
-    console.error(
-      `[chunker] tree-sitter parse failed for ${filePath}: ${err instanceof Error ? err.message : err}`,
+    log.error(
+      `tree-sitter parse failed for ${filePath}: ${err instanceof Error ? err.message : err}`,
     );
     return [fallbackChunk(source, filePath, language)];
   }

--- a/src/chunker/json.ts
+++ b/src/chunker/json.ts
@@ -1,5 +1,8 @@
 import type { Chunk } from './types.ts';
 import { fallbackChunk } from './fallback.ts';
+import { createLogger } from '../utils/logger.ts';
+
+const log = createLogger('chunker');
 
 const SMALL_FILE_THRESHOLD = 50;
 
@@ -33,9 +36,7 @@ function chunkJSON(source: string, filePath: string): Chunk[] {
 
     return chunks.length > 0 ? chunks : [fallbackChunk(source, filePath, 'json')];
   } catch (err: unknown) {
-    console.warn(
-      `[chunker] JSON parse failed for ${filePath}: ${err instanceof Error ? err.message : err}`,
-    );
+    log.warn(`JSON parse failed for ${filePath}: ${err instanceof Error ? err.message : err}`);
     return [fallbackChunk(source, filePath, 'json')];
   }
 }

--- a/src/embedder.ts
+++ b/src/embedder.ts
@@ -1,5 +1,8 @@
 import env from './env.ts';
 import type { Chunk } from './chunker/types.ts';
+import { createLogger } from './utils/logger.ts';
+
+const log = createLogger('embedder');
 
 const VOYAGE_API_URL = 'https://api.voyageai.com/v1/embeddings';
 const VOYAGE_MODEL = 'voyage-code-3';
@@ -57,8 +60,8 @@ async function embedBatch(
         );
       }
       const delay = BASE_DELAY_MS * Math.pow(2, attempt);
-      console.warn(
-        `[embedder] Network error. Retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES + 1})...`,
+      log.warn(
+        `Network error. Retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES + 1})...`,
       );
       await sleep(delay);
       continue;
@@ -69,8 +72,8 @@ async function embedBatch(
         throw new Error(`Voyage API error ${response.status} after ${MAX_RETRIES + 1} attempts`);
       }
       const delay = BASE_DELAY_MS * Math.pow(2, attempt);
-      console.warn(
-        `[embedder] ${response.status} response. Retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES + 1})...`,
+      log.warn(
+        `${response.status} response. Retrying in ${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES + 1})...`,
       );
       await sleep(delay);
       continue;
@@ -111,9 +114,7 @@ async function embedChunks(chunks: Chunk[]): Promise<number[][]> {
     const concurrentBatches = batches.slice(i, i + MAX_CONCURRENCY);
     const promises = concurrentBatches.map((batch, j) => {
       const batchNum = i + j + 1;
-      console.log(
-        `[embedder] Embedding batch ${batchNum}/${totalBatches} (${batch.length} chunks)...`,
-      );
+      log.info(`Embedding batch ${batchNum}/${totalBatches} (${batch.length} chunks)...`);
       return embedBatch(batch, 'document');
     });
 
@@ -125,9 +126,9 @@ async function embedChunks(chunks: Chunk[]): Promise<number[][]> {
       if (result.status === 'fulfilled') {
         results[i + j] = result.value;
       } else {
-        console.error(
-          `[embedder] Batch ${i + j + 1}/${totalBatches} failed in concurrent window:`,
-          result.reason,
+        log.error(
+          { err: result.reason },
+          `Batch ${i + j + 1}/${totalBatches} failed in concurrent window`,
         );
         failed.push(i + j);
       }
@@ -135,7 +136,7 @@ async function embedChunks(chunks: Chunk[]): Promise<number[][]> {
 
     // Retry failed batches sequentially (avoids concurrent retry stampede)
     for (const idx of failed) {
-      console.warn(`[embedder] Retrying batch ${idx + 1}/${totalBatches}...`);
+      log.warn(`Retrying batch ${idx + 1}/${totalBatches}...`);
       try {
         results[idx] = await embedBatch(batches[idx], 'document');
       } catch (retryErr: unknown) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -5,6 +5,7 @@ const envSchema = z.object({
   QDRANT_URL: z.string().url('QDRANT_URL must be a valid URL').optional(),
   QDRANT_KEY: z.string().min(1, 'QDRANT_KEY must not be empty').optional(),
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent']).default('info'),
 });
 
 const result = envSchema.safeParse(process.env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,9 @@ import './env.ts';
 import { walkFiles } from './walker.ts';
 import { chunkFile } from './chunker/index.ts';
 import { getLanguage } from './languages.ts';
+import { createLogger } from './utils/logger.ts';
+
+const log = createLogger('index');
 
 async function indexAction(targetDir: string): Promise<void> {
   const resolvedDir = path.resolve(targetDir);
@@ -18,24 +21,24 @@ async function indexAction(targetDir: string): Promise<void> {
   try {
     const stat = await fs.stat(resolvedDir);
     if (!stat.isDirectory()) {
-      console.error(`[index] "${resolvedDir}" is not a directory.`);
+      log.error(`"${resolvedDir}" is not a directory.`);
       process.exitCode = 1;
       return;
     }
   } catch {
-    console.error(
-      `[index] Cannot access "${resolvedDir}". Check that the path exists and you have read permissions.`,
+    log.error(
+      `Cannot access "${resolvedDir}". Check that the path exists and you have read permissions.`,
     );
     process.exitCode = 1;
     return;
   }
 
-  console.log(`[index] Scanning ${resolvedDir}...`);
-  console.time('[index] Done');
+  log.info(`Scanning ${resolvedDir}...`);
+  const startTime = Date.now();
 
   const files = await walkFiles(resolvedDir);
   if (files.length === 0) {
-    console.log('[index] No supported files found.');
+    log.info('No supported files found.');
     return;
   }
 
@@ -52,8 +55,8 @@ async function indexAction(targetDir: string): Promise<void> {
     .map(([lang, count]) => `${count} ${lang}`)
     .join(', ');
 
-  console.log(`[index] Found ${files.length} files (${breakdown})`);
-  console.log('[index] Chunking files...');
+  log.info(`Found ${files.length} files (${breakdown})`);
+  log.info('Chunking files...');
 
   let totalChunks = 0;
   let erroredFiles = 0;
@@ -64,25 +67,27 @@ async function indexAction(targetDir: string): Promise<void> {
       totalChunks += chunks.length;
     } catch (err: unknown) {
       erroredFiles++;
-      console.error(`[index] Failed to chunk ${file}: ${err instanceof Error ? err.message : err}`);
+      log.error(`Failed to chunk ${file}: ${err instanceof Error ? err.message : err}`);
     }
   }
 
-  console.log(`[index] Created ${totalChunks} chunks from ${files.length} files`);
+  log.info(`Created ${totalChunks} chunks from ${files.length} files`);
   if (erroredFiles > 0) {
-    console.warn(`[index] ${erroredFiles} files failed to chunk (see errors above)`);
+    log.warn(`${erroredFiles} files failed to chunk (see errors above)`);
     process.exitCode = 1;
   }
-  console.timeEnd('[index] Done');
+  log.info(`Done in ${Date.now() - startTime}ms`);
 }
 
 function searchAction(query: string, options: { mode: string }): void {
-  console.log(`[search] TODO: search for "${query}" with mode "${options.mode}" (Phase 4)`);
+  const searchLog = createLogger('search');
+  searchLog.info(`TODO: search for "${query}" with mode "${options.mode}" (Phase 4)`);
 }
 
 function watchAction(targetDir: string): void {
+  const watchLog = createLogger('watch');
   const resolvedDir = path.resolve(targetDir);
-  console.log(`[watch] TODO: watch ${resolvedDir} for changes (Phase 6)`);
+  watchLog.info(`TODO: watch ${resolvedDir} for changes (Phase 6)`);
 }
 
 const program = new Command();
@@ -116,6 +121,7 @@ program
   .action(watchAction);
 
 program.parseAsync().catch((err: unknown) => {
-  console.error('[fatal]', err instanceof Error ? (err.stack ?? err.message) : err);
+  const fatalLog = createLogger('fatal');
+  fatalLog.error(err instanceof Error ? (err.stack ?? err.message) : err);
   process.exit(1);
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,24 @@
+import pino from 'pino';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+const rootLogger = pino({
+  level: process.env.LOG_LEVEL ?? 'info',
+  transport: isProduction
+    ? undefined
+    : {
+        target: 'pino-pretty',
+        options: {
+          colorize: true,
+          translateTime: 'SYS:HH:MM:ss',
+          ignore: 'pid,hostname',
+          messageFormat: '[{module}] {msg}',
+        },
+      },
+});
+
+function createLogger(module: string) {
+  return rootLogger.child({ module });
+}
+
+export { createLogger, rootLogger };

--- a/src/walker.ts
+++ b/src/walker.ts
@@ -4,6 +4,9 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import fg from 'fast-glob';
 import { getLanguage } from './languages.ts';
+import { createLogger } from './utils/logger.ts';
+
+const log = createLogger('walker');
 
 const execFileAsync = promisify(execFile);
 const MAX_BUFFER = 10 * 1024 * 1024;
@@ -32,7 +35,7 @@ async function isBinary(filePath: string): Promise<boolean> {
   } catch (err: unknown) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code !== 'ENOENT') {
-      console.warn(`[walker] Could not read ${filePath} for binary check (${code ?? err})`);
+      log.warn(`Could not read ${filePath} for binary check (${code ?? err})`);
     }
     return true;
   } finally {
@@ -49,8 +52,8 @@ async function discoverFiles(rootDir: string): Promise<string[]> {
     );
     return stdout.split('\n').filter(Boolean);
   } catch (err: unknown) {
-    console.warn(
-      `[walker] git ls-files failed, falling back to fast-glob (.gitignore rules will NOT apply): ${err instanceof Error ? err.message : err}`,
+    log.warn(
+      `git ls-files failed, falling back to fast-glob (.gitignore rules will NOT apply): ${err instanceof Error ? err.message : err}`,
     );
     const files = await fg('**/*', {
       cwd: rootDir,


### PR DESCRIPTION
## Summary
- Add `pino` + `pino-pretty` for production-grade structured logging
- Create `src/utils/logger.ts` with `createLogger(module)` factory using pino child loggers
- Replace all `console.log/warn/error` with typed pino loggers across 6 source files
- **Dev mode**: human-readable colored output with timestamps via `pino-pretty`
- **Production mode**: JSON logs ready for Datadog, Grafana Loki, CloudWatch, etc.
- Add `LOG_LEVEL` env var to Zod schema (configurable at runtime: trace/debug/info/warn/error/fatal/silent)
- Replace `console.time/timeEnd` with manual timing for pino compatibility

## Why pino?
- Fastest Node.js logger (30x faster than winston)
- JSON by default (production) + pretty-print (dev) via transports
- Child loggers with module context — single `createLogger('embedder')` call per file
- Used by Fastify, Platformatic, NestJS, and most production Node.js services
- Zero-config swap point — if we ever need to change loggers, it's one file

## Test plan
- [x] All 75 tests pass (4 test files)
- [x] TypeScript compiles with no errors
- [x] ESLint + Prettier clean
- [x] Build succeeds
- [x] Pino output visible in test runs with colored log levels

Closes #16