### PR TITLE
feat: SHA-256 file hashing (hash.ts)

### DIFF
--- a/src/lib/hash.test.ts
+++ b/src/lib/hash.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { hashFile, hashString } from './hash.ts';
+
+describe('hash', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'hash-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('hashFile', () => {
+    it('returns a 64-character hex string', async () => {
+      const filePath = path.join(tmpDir, 'sample.ts');
+      await fs.writeFile(filePath, 'const x = 1;');
+
+      const hash = await hashFile(filePath);
+
+      expect(hash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('returns the same hash for the same content', async () => {
+      const filePath = path.join(tmpDir, 'stable.ts');
+      await fs.writeFile(filePath, 'function hello() {}');
+
+      const hash1 = await hashFile(filePath);
+      const hash2 = await hashFile(filePath);
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it('returns different hashes for different content', async () => {
+      const fileA = path.join(tmpDir, 'a.ts');
+      const fileB = path.join(tmpDir, 'b.ts');
+      await fs.writeFile(fileA, 'const a = 1;');
+      await fs.writeFile(fileB, 'const b = 2;');
+
+      const hashA = await hashFile(fileA);
+      const hashB = await hashFile(fileB);
+
+      expect(hashA).not.toBe(hashB);
+    });
+
+    it('matches hashString for the same content', async () => {
+      const content = 'export function greet() { return "hi"; }';
+      const filePath = path.join(tmpDir, 'greet.ts');
+      await fs.writeFile(filePath, content);
+
+      const fileHash = await hashFile(filePath);
+      const stringHash = hashString(content);
+
+      expect(fileHash).toBe(stringHash);
+    });
+
+    it('returns known SHA-256 for an empty file', async () => {
+      const filePath = path.join(tmpDir, 'empty.txt');
+      await fs.writeFile(filePath, '');
+
+      const hash = await hashFile(filePath);
+
+      expect(hash).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+    });
+
+    it('throws on non-existent file', async () => {
+      await expect(hashFile(path.join(tmpDir, 'missing.ts'))).rejects.toThrow();
+    });
+  });
+
+  describe('hashString', () => {
+    it('returns a 64-character hex string', () => {
+      const hash = hashString('function hello() {}');
+
+      expect(hash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it('returns consistent results for the same input', () => {
+      const input = 'const x = 42;';
+
+      expect(hashString(input)).toBe(hashString(input));
+    });
+
+    it('returns different hashes for different input', () => {
+      expect(hashString('hello')).not.toBe(hashString('world'));
+    });
+
+    it('returns the known SHA-256 of an empty string', () => {
+      expect(hashString('')).toBe(
+        'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      );
+    });
+  });
+});

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -1,0 +1,29 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import { createLogger } from '../utils/logger.ts';
+
+const log = createLogger('hash');
+
+/**
+ * Compute SHA-256 hash of a file's contents.
+ * Returns the hex-encoded digest (64-char string).
+ */
+async function hashFile(filePath: string): Promise<string> {
+  try {
+    const content = await fs.readFile(filePath);
+    return createHash('sha256').update(content).digest('hex');
+  } catch (err: unknown) {
+    log.error(`Failed to hash file ${filePath}: ${err instanceof Error ? err.message : err}`);
+    throw err;
+  }
+}
+
+/**
+ * Compute SHA-256 hash of a string (used for chunk content hashing).
+ * Returns the hex-encoded digest.
+ */
+function hashString(content: string): string {
+  return createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+export { hashFile, hashString };


### PR DESCRIPTION
## Summary
- Add `src/lib/hash.ts` with `hashFile()` and `hashString()` utilities
- `hashFile` reads file as raw bytes and returns hex SHA-256 digest
- `hashString` hashes string content directly (for chunk deduplication)
- 10 tests covering determinism, correctness (golden values), format, and error handling

## Part of
Phase 3: Vector Store + SQLite Cache

Closes #23

## Test plan
- [x] `hashFile` returns 64-char hex string
- [x] Same file → same hash (deterministic)
- [x] Different files → different hashes
- [x] `hashFile` matches `hashString` for same content (cross-validation)
- [x] Empty file returns known SHA-256 constant
- [x] Non-existent file throws with error log