### PR TITLE
feat: SQLite cache with better-sqlite3 (db.ts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env.local
 *.wasm
 *.tsbuildinfo
+.code-indexer/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "better-sqlite3": "^12.8.0",
         "commander": "^14.0.3",
         "dotenv": "^16.6.1",
         "fast-glob": "^3.3.3",
@@ -28,6 +29,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^22.19.15",
         "@types/pino-pretty": "^4.7.5",
         "@vitest/coverage-v8": "^4.1.0",
@@ -1145,6 +1147,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1693,6 +1705,60 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
@@ -1718,6 +1784,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -1727,6 +1817,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -1792,6 +1888,30 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1803,7 +1923,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2083,6 +2202,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2164,6 +2292,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2214,6 +2348,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2241,6 +2381,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
@@ -2277,6 +2423,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2296,6 +2462,18 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2771,6 +2949,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -2795,6 +2985,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2822,12 +3018,30 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "8.6.0",
@@ -3064,6 +3278,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3152,6 +3393,44 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -3238,6 +3517,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -3267,7 +3566,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -3305,6 +3603,51 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
@@ -3348,6 +3691,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -3371,6 +3723,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/thread-stream": {
@@ -3670,6 +4050,18 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3737,6 +4129,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "better-sqlite3": "^12.8.0",
     "commander": "^14.0.3",
     "dotenv": "^16.6.1",
     "fast-glob": "^3.3.3",
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^22.19.15",
     "@types/pino-pretty": "^4.7.5",
     "@vitest/coverage-v8": "^4.1.0",

--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  initDb,
+  closeDb,
+  getFileHash,
+  setFileHash,
+  deleteFileHash,
+  getAllFileHashes,
+  getChunksByFile,
+  upsertChunk,
+  deleteChunksByFile,
+} from './db.ts';
+
+describe('db', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'db-test-'));
+    initDb(tmpDir);
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  describe('initDb', () => {
+    it('creates the .code-indexer directory and cache.db file', async () => {
+      const dbPath = path.join(tmpDir, '.code-indexer', 'cache.db');
+      const stat = await fs.stat(dbPath);
+      expect(stat.isFile()).toBe(true);
+    });
+
+    it('returns the same instance on second call', () => {
+      const db1 = initDb(tmpDir);
+      const db2 = initDb(tmpDir);
+      expect(db1).toBe(db2);
+    });
+  });
+
+  describe('file_hashes', () => {
+    it('returns undefined for unknown file', () => {
+      expect(getFileHash('/unknown/file.ts')).toBeUndefined();
+    });
+
+    it('sets and gets a file hash', () => {
+      setFileHash('/src/index.ts', 'abc123');
+
+      const row = getFileHash('/src/index.ts');
+      expect(row).toBeDefined();
+      expect(row!.sha256).toBe('abc123');
+      expect(row!.file_path).toBe('/src/index.ts');
+      expect(row!.updated_at).toBeGreaterThan(0);
+    });
+
+    it('updates hash on conflict (same file path)', () => {
+      setFileHash('/src/index.ts', 'hash-v1');
+      setFileHash('/src/index.ts', 'hash-v2');
+
+      const row = getFileHash('/src/index.ts');
+      expect(row!.sha256).toBe('hash-v2');
+    });
+
+    it('deletes a file hash', () => {
+      setFileHash('/src/index.ts', 'abc123');
+      deleteFileHash('/src/index.ts');
+
+      expect(getFileHash('/src/index.ts')).toBeUndefined();
+    });
+
+    it('delete is a no-op for non-existent file', () => {
+      expect(() => deleteFileHash('/missing.ts')).not.toThrow();
+    });
+
+    it('gets all file hashes', () => {
+      setFileHash('/src/a.ts', 'hash-a');
+      setFileHash('/src/b.ts', 'hash-b');
+      setFileHash('/src/c.ts', 'hash-c');
+
+      const all = getAllFileHashes();
+      expect(all).toHaveLength(3);
+      expect(all.map((r) => r.file_path).sort()).toEqual(['/src/a.ts', '/src/b.ts', '/src/c.ts']);
+    });
+  });
+
+  describe('chunk_cache', () => {
+    it('returns empty array for file with no chunks', () => {
+      expect(getChunksByFile('/unknown.ts')).toEqual([]);
+    });
+
+    it('upserts and retrieves chunks by file', () => {
+      upsertChunk('chunk-hash-1', 'qdrant-id-1', '/src/index.ts', 1, 25);
+      upsertChunk('chunk-hash-2', 'qdrant-id-2', '/src/index.ts', 27, 50);
+
+      const chunks = getChunksByFile('/src/index.ts');
+      expect(chunks).toHaveLength(2);
+      expect(chunks[0].chunk_hash).toBe('chunk-hash-1');
+      expect(chunks[0].qdrant_id).toBe('qdrant-id-1');
+      expect(chunks[0].line_start).toBe(1);
+      expect(chunks[0].line_end).toBe(25);
+    });
+
+    it('updates chunk on conflict (same chunk_hash)', () => {
+      upsertChunk('chunk-hash-1', 'old-id', '/src/index.ts', 1, 10);
+      upsertChunk('chunk-hash-1', 'new-id', '/src/index.ts', 1, 15);
+
+      const chunks = getChunksByFile('/src/index.ts');
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0].qdrant_id).toBe('new-id');
+      expect(chunks[0].line_end).toBe(15);
+    });
+
+    it('does not mix chunks from different files', () => {
+      upsertChunk('hash-a', 'id-a', '/src/a.ts', 1, 10);
+      upsertChunk('hash-b', 'id-b', '/src/b.ts', 1, 20);
+
+      expect(getChunksByFile('/src/a.ts')).toHaveLength(1);
+      expect(getChunksByFile('/src/b.ts')).toHaveLength(1);
+    });
+
+    it('deletes chunks by file and returns deleted rows', () => {
+      upsertChunk('hash-1', 'qid-1', '/src/index.ts', 1, 10);
+      upsertChunk('hash-2', 'qid-2', '/src/index.ts', 11, 20);
+      upsertChunk('hash-3', 'qid-3', '/src/other.ts', 1, 5);
+
+      const deleted = deleteChunksByFile('/src/index.ts');
+
+      expect(deleted).toHaveLength(2);
+      expect(deleted.map((d) => d.qdrant_id).sort()).toEqual(['qid-1', 'qid-2']);
+
+      // Other file's chunks are untouched
+      expect(getChunksByFile('/src/other.ts')).toHaveLength(1);
+
+      // Deleted file's chunks are gone
+      expect(getChunksByFile('/src/index.ts')).toEqual([]);
+    });
+
+    it('delete returns empty array when no chunks exist', () => {
+      expect(deleteChunksByFile('/missing.ts')).toEqual([]);
+    });
+  });
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,173 @@
+import Database from 'better-sqlite3';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createLogger } from '../utils/logger.ts';
+
+const log = createLogger('db');
+
+const DEFAULT_DB_DIR = '.code-indexer';
+const DB_FILENAME = 'cache.db';
+
+let db: Database.Database | null = null;
+let initializedRootDir: string | null = null;
+
+interface FileHashRow {
+  file_path: string;
+  sha256: string;
+  updated_at: number;
+}
+
+interface ChunkCacheRow {
+  chunk_hash: string;
+  qdrant_id: string;
+  file_path: string;
+  line_start: number;
+  line_end: number;
+}
+
+function getDbPath(rootDir: string): string {
+  return path.join(rootDir, DEFAULT_DB_DIR, DB_FILENAME);
+}
+
+function initDb(rootDir: string): Database.Database {
+  if (db) {
+    if (initializedRootDir && initializedRootDir !== rootDir) {
+      throw new Error(
+        `Database already initialized for "${initializedRootDir}", cannot reinitialize for "${rootDir}". Call closeDb() first.`,
+      );
+    }
+    return db;
+  }
+
+  const dbPath = getDbPath(rootDir);
+
+  // Ensure the .code-indexer directory exists (recursive mkdir is a no-op if it already exists)
+  fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+  db = new Database(dbPath);
+
+  // WAL mode: reads don't block writes, better concurrent performance
+  db.pragma('journal_mode = WAL');
+
+  // Create tables if they don't exist
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS file_hashes (
+      file_path TEXT PRIMARY KEY,
+      sha256 TEXT NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS chunk_cache (
+      chunk_hash TEXT PRIMARY KEY,
+      qdrant_id TEXT NOT NULL,
+      file_path TEXT NOT NULL,
+      line_start INTEGER NOT NULL,
+      line_end INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_chunk_cache_file_path
+      ON chunk_cache(file_path);
+  `);
+
+  initializedRootDir = rootDir;
+  log.info(`SQLite database initialized at ${dbPath}`);
+  return db;
+}
+
+function getDb(): Database.Database {
+  if (!db) {
+    throw new Error('Database not initialized. Call initDb(rootDir) first.');
+  }
+  return db;
+}
+
+// --- file_hashes operations ---
+
+function getFileHash(filePath: string): FileHashRow | undefined {
+  const row = getDb().prepare('SELECT * FROM file_hashes WHERE file_path = ?').get(filePath);
+  return row as FileHashRow | undefined;
+}
+
+function setFileHash(filePath: string, sha256: string): void {
+  getDb()
+    .prepare(
+      `INSERT INTO file_hashes (file_path, sha256, updated_at)
+       VALUES (?, ?, ?)
+       ON CONFLICT(file_path) DO UPDATE SET sha256 = excluded.sha256, updated_at = excluded.updated_at`,
+    )
+    .run(filePath, sha256, Date.now());
+}
+
+function deleteFileHash(filePath: string): void {
+  getDb().prepare('DELETE FROM file_hashes WHERE file_path = ?').run(filePath);
+}
+
+function getAllFileHashes(): FileHashRow[] {
+  const rows = getDb().prepare('SELECT * FROM file_hashes').all();
+  return rows as FileHashRow[];
+}
+
+// --- chunk_cache operations ---
+
+function getChunksByFile(filePath: string): ChunkCacheRow[] {
+  const rows = getDb().prepare('SELECT * FROM chunk_cache WHERE file_path = ?').all(filePath);
+  return rows as ChunkCacheRow[];
+}
+
+function upsertChunk(
+  chunkHash: string,
+  qdrantId: string,
+  filePath: string,
+  lineStart: number,
+  lineEnd: number,
+): void {
+  getDb()
+    .prepare(
+      `INSERT INTO chunk_cache (chunk_hash, qdrant_id, file_path, line_start, line_end)
+       VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(chunk_hash) DO UPDATE SET
+         qdrant_id = excluded.qdrant_id,
+         file_path = excluded.file_path,
+         line_start = excluded.line_start,
+         line_end = excluded.line_end`,
+    )
+    .run(chunkHash, qdrantId, filePath, lineStart, lineEnd);
+}
+
+function deleteChunksByFile(filePath: string): ChunkCacheRow[] {
+  const db = getDb();
+  const txn = db.transaction(() => {
+    const chunks = db
+      .prepare('SELECT * FROM chunk_cache WHERE file_path = ?')
+      .all(filePath) as ChunkCacheRow[];
+    db.prepare('DELETE FROM chunk_cache WHERE file_path = ?').run(filePath);
+    return chunks;
+  });
+  return txn();
+}
+
+// --- lifecycle ---
+
+function closeDb(): void {
+  if (db) {
+    db.close();
+    db = null;
+    initializedRootDir = null;
+    log.info('SQLite database closed');
+  }
+}
+
+export {
+  initDb,
+  getDb,
+  closeDb,
+  getDbPath,
+  getFileHash,
+  setFileHash,
+  deleteFileHash,
+  getAllFileHashes,
+  getChunksByFile,
+  upsertChunk,
+  deleteChunksByFile,
+};
+export type { FileHashRow, ChunkCacheRow };


### PR DESCRIPTION
## Summary
- Add `src/lib/db.ts` with SQLite cache using better-sqlite3
- Two tables: `file_hashes` (change detection) and `chunk_cache` (Qdrant ID mapping)
- WAL mode for concurrent read/write performance
- UPSERT via ON CONFLICT DO UPDATE (atomic insert-or-update)
- Transactional `deleteChunksByFile` (SELECT + DELETE in one transaction)
- Singleton with rootDir validation — throws if reinitialized with different dir
- `.code-indexer/` added to .gitignore (SQLite cache directory)
- 14 tests covering CRUD, upsert conflict, isolation, atomic deletes

## Part of
Phase 3: Vector Store + SQLite Cache

Closes #24

## Test plan
- [x] Creates .code-indexer directory and cache.db file
- [x] Singleton returns same instance on second call
- [x] CRUD operations for file_hashes table
- [x] UPSERT handles conflicts correctly
- [x] Chunk isolation between different files
- [x] deleteChunksByFile returns deleted rows atomically
- [x] No-op on delete of non-existent entries