### PR TITLE
feat: graceful shutdown handler (shutdown.ts)

### DIFF
--- a/src/lib/shutdown.test.ts
+++ b/src/lib/shutdown.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We need a fresh module for each test because shutdown has module-level state
+type CleanupFn = () => void | Promise<void>;
+let onShutdown: (fn: CleanupFn) => void;
+let runCleanup: () => Promise<void>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const mod = await import('./shutdown.ts');
+  onShutdown = mod.onShutdown;
+  runCleanup = mod.runCleanup;
+});
+
+describe('shutdown', () => {
+  it('runs registered cleanup functions in order', async () => {
+    const order: number[] = [];
+
+    onShutdown(() => {
+      order.push(1);
+    });
+    onShutdown(() => {
+      order.push(2);
+    });
+    onShutdown(() => {
+      order.push(3);
+    });
+
+    await runCleanup();
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('handles async cleanup functions', async () => {
+    let cleaned = false;
+
+    onShutdown(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      cleaned = true;
+    });
+
+    await runCleanup();
+
+    expect(cleaned).toBe(true);
+  });
+
+  it('continues cleanup even if one function throws', async () => {
+    const results: string[] = [];
+
+    onShutdown(() => {
+      results.push('first');
+    });
+    onShutdown(() => {
+      throw new Error('cleanup failed');
+    });
+    onShutdown(() => {
+      results.push('third');
+    });
+
+    await runCleanup();
+
+    expect(results).toEqual(['first', 'third']);
+  });
+
+  it('only runs cleanup once (idempotent)', async () => {
+    let count = 0;
+    onShutdown(() => {
+      count++;
+    });
+
+    await runCleanup();
+    await runCleanup();
+
+    expect(count).toBe(1);
+  });
+
+  it('does nothing with no registered functions', async () => {
+    await expect(runCleanup()).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/shutdown.ts
+++ b/src/lib/shutdown.ts
@@ -1,0 +1,46 @@
+import { createLogger } from '../utils/logger.ts';
+
+const log = createLogger('shutdown');
+
+type CleanupFn = () => void | Promise<void>;
+
+const cleanupFns: CleanupFn[] = [];
+let isShuttingDown = false;
+let handlersRegistered = false;
+
+function onShutdown(fn: CleanupFn): void {
+  cleanupFns.push(fn);
+}
+
+async function runCleanup(): Promise<void> {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+
+  log.info('Shutting down gracefully...');
+
+  for (const fn of cleanupFns) {
+    try {
+      await fn();
+    } catch (err: unknown) {
+      log.error(`Cleanup error: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  log.info('Cleanup complete');
+}
+
+function registerShutdownHandlers(): void {
+  if (handlersRegistered) return;
+  handlersRegistered = true;
+
+  const handler = async (signal: NodeJS.Signals) => {
+    log.info(`Received ${signal}`);
+    await runCleanup();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', handler);
+  process.on('SIGTERM', handler);
+}
+
+export { onShutdown, runCleanup, registerShutdownHandlers };


### PR DESCRIPTION
## Summary
- Add `src/lib/shutdown.ts` — callback registry pattern for clean resource cleanup
- Handles SIGINT (Ctrl+C) and SIGTERM (Docker/Kubernetes process managers)
- Sequential cleanup with error isolation — one failing cleanup doesn't block others
- Idempotent execution guard (double-signal protection)
- Double-registration guard (prevents listener stacking)
- 5 tests covering order, async support, error resilience, idempotency

## Part of
Phase 3: Vector Store + SQLite Cache

Closes #26

## Test plan
- [x] Runs cleanup functions in registration order
- [x] Handles async cleanup functions
- [x] Continues cleanup even if one function throws
- [x] Only runs cleanup once (idempotent)
- [x] No-op with no registered functions