### PR TITLE
feat: Qdrant vector store integration (store.ts)

### DIFF
--- a/src/lib/embedder.ts
+++ b/src/lib/embedder.ts
@@ -8,6 +8,7 @@ interface EmbeddingProvider {
   name: string;
   apiUrl: string;
   model: string;
+  dimension: number;
   apiKey: string;
   batchSize: number;
   maxConcurrency: number;
@@ -50,6 +51,7 @@ function getProvider(): EmbeddingProvider {
       name: 'openai',
       apiUrl: 'https://api.openai.com/v1/embeddings',
       model: 'text-embedding-3-small',
+      dimension: 1536,
       apiKey,
       batchSize: 128,
       maxConcurrency: 3,
@@ -71,6 +73,7 @@ function getProvider(): EmbeddingProvider {
     name: 'voyage',
     apiUrl: 'https://api.voyageai.com/v1/embeddings',
     model: 'voyage-code-3',
+    dimension: 1024,
     apiKey,
     batchSize: 8,
     maxConcurrency: 1,

--- a/src/lib/store.test.ts
+++ b/src/lib/store.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../config/env.ts', () => ({
+  default: {
+    EMBEDDING_PROVIDER: 'openai',
+    OPENAI_API_KEY: 'test-key',
+    QDRANT_URL: 'https://test.qdrant.io',
+    QDRANT_KEY: 'test-qdrant-key',
+    NODE_ENV: 'test',
+  },
+}));
+
+import {
+  ensureCollection,
+  upsertPoints,
+  deletePoints,
+  searchPoints,
+  COLLECTION_NAME,
+} from './store.ts';
+import type { UpsertPoint } from './store.ts';
+
+function mockJsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makePoint(index: number): UpsertPoint {
+  return {
+    embedding: Array.from({ length: 1536 }, (_, d) => index * 0.001 + d * 0.0001),
+    payload: {
+      filePath: `/src/file-${index}.ts`,
+      lineStart: 1,
+      lineEnd: 25,
+      language: 'typescript',
+      chunkHash: `hash-${index}`,
+    },
+  };
+}
+
+function getRequestBody(callIndex = 0) {
+  return JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[callIndex][1].body);
+}
+
+function getRequestUrl(callIndex = 0): string {
+  return (fetch as ReturnType<typeof vi.fn>).mock.calls[callIndex][0];
+}
+
+describe('store', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('ensureCollection', () => {
+    it('skips creation if collection already exists', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({ result: { status: 'green' } }, 200),
+      );
+
+      await ensureCollection();
+
+      expect(fetch).toHaveBeenCalledOnce();
+      expect(getRequestUrl(0)).toContain(`/collections/${COLLECTION_NAME}`);
+    });
+
+    it('creates collection if it does not exist', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      fetchSpy
+        .mockResolvedValueOnce(mockJsonResponse({ status: { error: 'not found' } }, 404))
+        .mockResolvedValueOnce(mockJsonResponse({ result: true }, 200));
+
+      await ensureCollection();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      const createBody = getRequestBody(1);
+      expect(createBody.vectors.size).toBe(1536);
+      expect(createBody.vectors.distance).toBe('Cosine');
+    });
+
+    it('throws on non-200/non-404 status from GET check', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({ status: { error: 'unauthorized' } }, 401),
+      );
+
+      await expect(ensureCollection()).rejects.toThrow('collection check failed with status 401');
+    });
+
+    it('throws on collection creation failure', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      fetchSpy
+        .mockResolvedValueOnce(mockJsonResponse({}, 404))
+        .mockResolvedValueOnce(mockJsonResponse({ status: { error: 'bad request' } }, 400));
+
+      await expect(ensureCollection()).rejects.toThrow('Failed to create Qdrant collection');
+    });
+  });
+
+  describe('upsertPoints', () => {
+    it('returns empty array for empty input', async () => {
+      const ids = await upsertPoints([]);
+      expect(ids).toEqual([]);
+    });
+
+    it('upserts points and returns UUIDs', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({ result: { status: 'completed' } }),
+      );
+
+      const points = [makePoint(0), makePoint(1), makePoint(2)];
+      const ids = await upsertPoints(points);
+
+      expect(ids).toHaveLength(3);
+      ids.forEach((id) => {
+        expect(id).toMatch(/^[a-f0-9-]{36}$/);
+      });
+
+      const body = getRequestBody(0);
+      expect(body.points).toHaveLength(3);
+      expect(body.points[0].vector).toHaveLength(1536);
+      expect(body.points[0].payload.filePath).toBe('/src/file-0.ts');
+    });
+
+    it('sends correct auth headers', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({ result: { status: 'completed' } }),
+      );
+
+      await upsertPoints([makePoint(0)]);
+
+      const headers = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].headers;
+      expect(headers['api-key']).toBe('test-qdrant-key');
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('batches large upserts into chunks of 100', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      fetchSpy.mockImplementation(async () =>
+        mockJsonResponse({ result: { status: 'completed' } }),
+      );
+
+      const points = Array.from({ length: 250 }, (_, i) => makePoint(i));
+      const ids = await upsertPoints(points);
+
+      expect(ids).toHaveLength(250);
+      // 250 points = 3 batches (100 + 100 + 50)
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+      expect(getRequestBody(0).points).toHaveLength(100);
+      expect(getRequestBody(1).points).toHaveLength(100);
+      expect(getRequestBody(2).points).toHaveLength(50);
+    });
+
+    it('throws on non-retryable upsert failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({ status: { error: 'bad request' } }, 400),
+      );
+
+      await expect(upsertPoints([makePoint(0)])).rejects.toThrow('Failed to upsert points');
+    });
+  });
+
+  describe('deletePoints', () => {
+    it('is a no-op for empty ids array', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      await deletePoints([]);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('sends delete request with point ids', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({ result: { status: 'completed' } }),
+      );
+
+      await deletePoints(['id-1', 'id-2', 'id-3']);
+
+      const body = getRequestBody(0);
+      expect(body.points).toEqual(['id-1', 'id-2', 'id-3']);
+      expect(getRequestUrl(0)).toContain('/points/delete');
+    });
+
+    it('throws on delete failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({ status: { error: 'not found' } }, 404),
+      );
+
+      await expect(deletePoints(['bad-id'])).rejects.toThrow('Failed to delete points');
+    });
+  });
+
+  describe('searchPoints', () => {
+    it('returns search results with scores and payloads', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({
+          result: [
+            {
+              id: 'uuid-1',
+              score: 0.95,
+              payload: {
+                filePath: '/src/auth.ts',
+                lineStart: 10,
+                lineEnd: 30,
+                language: 'typescript',
+                chunkHash: 'hash-1',
+              },
+            },
+            {
+              id: 'uuid-2',
+              score: 0.87,
+              payload: {
+                filePath: '/src/login.ts',
+                lineStart: 1,
+                lineEnd: 15,
+                language: 'typescript',
+                chunkHash: 'hash-2',
+              },
+            },
+          ],
+        }),
+      );
+
+      const queryVector = Array.from({ length: 1536 }, () => 0.1);
+      const results = await searchPoints(queryVector, 5);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].score).toBe(0.95);
+      expect(results[0].payload.filePath).toBe('/src/auth.ts');
+      expect(results[1].score).toBe(0.87);
+
+      const body = getRequestBody(0);
+      expect(body.vector).toHaveLength(1536);
+      expect(body.limit).toBe(5);
+      expect(body.with_payload).toBe(true);
+    });
+
+    it('throws on search failure', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+        mockJsonResponse({ status: { error: 'collection not found' } }, 404),
+      );
+
+      await expect(searchPoints([], 10)).rejects.toThrow('Qdrant search failed');
+    });
+  });
+});

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,218 @@
+import { randomUUID } from 'node:crypto';
+import env from '../config/env.ts';
+import { createLogger } from '../utils/logger.ts';
+import { getProvider } from './embedder.ts';
+
+const log = createLogger('store');
+
+const COLLECTION_NAME = 'code-indexer';
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+interface PointPayload {
+  filePath: string;
+  lineStart: number;
+  lineEnd: number;
+  language: string;
+  chunkHash: string;
+}
+
+interface SearchResult {
+  id: string;
+  score: number;
+  payload: PointPayload;
+}
+
+let cachedQdrantConfig: { url: string; apiKey: string } | null = null;
+
+function getQdrantConfig(): { url: string; apiKey: string } {
+  if (cachedQdrantConfig) return cachedQdrantConfig;
+
+  const url = env.QDRANT_URL;
+  const apiKey = env.QDRANT_KEY;
+  if (!url || !apiKey) {
+    throw new Error(
+      'QDRANT_URL and QDRANT_KEY are required for vector store. Set them in your .env file.',
+    );
+  }
+  cachedQdrantConfig = { url, apiKey };
+  return cachedQdrantConfig;
+}
+
+function isRetryable(status: number): boolean {
+  return status === 429 || (status >= 500 && status < 600);
+}
+
+function sleepWithJitter(baseMs: number): Promise<void> {
+  const jittered = Math.floor(baseMs * (0.5 + Math.random()));
+  return new Promise((resolve) => setTimeout(resolve, jittered));
+}
+
+async function qdrantRequest(
+  path: string,
+  method: string,
+  body?: unknown,
+): Promise<{ status: number; data: unknown }> {
+  const { url, apiKey } = getQdrantConfig();
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    let response: Response;
+
+    try {
+      response = await fetch(`${url}${path}`, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'api-key': apiKey,
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+    } catch (err: unknown) {
+      if (attempt === MAX_RETRIES) {
+        throw new Error(
+          `Qdrant network error after ${MAX_RETRIES + 1} attempts: ${err instanceof Error ? err.message : err}`,
+          { cause: err },
+        );
+      }
+      const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+      log.warn(
+        `Qdrant network error. Retrying in ~${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES + 1})...`,
+      );
+      await sleepWithJitter(delay);
+      continue;
+    }
+
+    if (isRetryable(response.status)) {
+      if (attempt === MAX_RETRIES) {
+        const text = await response.text();
+        throw new Error(`Qdrant ${response.status} after ${MAX_RETRIES + 1} attempts: ${text}`);
+      }
+      const delay = BASE_DELAY_MS * Math.pow(2, attempt);
+      log.warn(
+        `Qdrant ${response.status}. Retrying in ~${delay}ms (attempt ${attempt + 1}/${MAX_RETRIES + 1})...`,
+      );
+      await sleepWithJitter(delay);
+      continue;
+    }
+
+    // Parse response body safely — not all error responses are JSON
+    let data: unknown;
+    try {
+      data = await response.json();
+    } catch {
+      data = await response.text();
+    }
+
+    return { status: response.status, data };
+  }
+
+  throw new Error('Unreachable');
+}
+
+async function ensureCollection(): Promise<void> {
+  const provider = getProvider();
+  const dimension = provider.dimension;
+
+  const { status, data } = await qdrantRequest(`/collections/${COLLECTION_NAME}`, 'GET');
+
+  if (status === 200) {
+    log.info(`Collection "${COLLECTION_NAME}" already exists`);
+    return;
+  }
+
+  if (status !== 404) {
+    throw new Error(
+      `Qdrant collection check failed with status ${status}: ${JSON.stringify(data)}`,
+    );
+  }
+
+  const { status: createStatus, data: createData } = await qdrantRequest(
+    `/collections/${COLLECTION_NAME}`,
+    'PUT',
+    {
+      vectors: {
+        size: dimension,
+        distance: 'Cosine',
+      },
+    },
+  );
+
+  if (createStatus !== 200) {
+    throw new Error(`Failed to create Qdrant collection: ${JSON.stringify(createData)}`);
+  }
+
+  log.info(`Created collection "${COLLECTION_NAME}" (${dimension} dimensions, cosine distance)`);
+}
+
+interface UpsertPoint {
+  embedding: number[];
+  payload: PointPayload;
+}
+
+async function upsertPoints(points: UpsertPoint[]): Promise<string[]> {
+  if (points.length === 0) return [];
+
+  const ids = points.map(() => randomUUID());
+
+  const qdrantPoints = points.map((p, i) => ({
+    id: ids[i],
+    vector: p.embedding,
+    payload: p.payload,
+  }));
+
+  const BATCH_SIZE = 100;
+  for (let i = 0; i < qdrantPoints.length; i += BATCH_SIZE) {
+    const batch = qdrantPoints.slice(i, i + BATCH_SIZE);
+    const { status, data } = await qdrantRequest(`/collections/${COLLECTION_NAME}/points`, 'PUT', {
+      points: batch,
+    });
+
+    if (status !== 200) {
+      throw new Error(`Failed to upsert points to Qdrant: ${JSON.stringify(data)}`);
+    }
+
+    log.info(
+      `Upserted batch ${Math.floor(i / BATCH_SIZE) + 1}/${Math.ceil(qdrantPoints.length / BATCH_SIZE)} (${batch.length} points)`,
+    );
+  }
+
+  return ids;
+}
+
+async function deletePoints(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+
+  const { status, data } = await qdrantRequest(
+    `/collections/${COLLECTION_NAME}/points/delete`,
+    'POST',
+    { points: ids },
+  );
+
+  if (status !== 200) {
+    throw new Error(`Failed to delete points from Qdrant: ${JSON.stringify(data)}`);
+  }
+
+  log.info(`Deleted ${ids.length} points from Qdrant`);
+}
+
+async function searchPoints(vector: number[], limit: number = 10): Promise<SearchResult[]> {
+  const { status, data } = await qdrantRequest(
+    `/collections/${COLLECTION_NAME}/points/search`,
+    'POST',
+    {
+      vector,
+      limit,
+      with_payload: true,
+    },
+  );
+
+  if (status !== 200) {
+    throw new Error(`Qdrant search failed: ${JSON.stringify(data)}`);
+  }
+
+  const result = data as { result: SearchResult[] };
+  return result.result;
+}
+
+export { ensureCollection, upsertPoints, deletePoints, searchPoints, COLLECTION_NAME };
+export type { PointPayload, SearchResult, UpsertPoint };


### PR DESCRIPTION
## Summary
- Add `src/lib/store.ts` — Qdrant Cloud vector store with plain fetch API
- Retry logic with exponential backoff + jitter (same pattern as embedder.ts)
- Safe JSON parsing — handles non-JSON error responses (502 from proxies, etc.)
- `ensureCollection` — creates only on 404, throws on other non-200 statuses
- `upsertPoints` — batched (100/batch), returns UUID point IDs
- `deletePoints` — removes vectors by ID
- `searchPoints` — top-K nearest neighbor search (foundation for Phase 4)
- Add `dimension` field to `EmbeddingProvider` interface in embedder.ts
- 14 tests covering collection lifecycle, upsert/delete/search, batching, auth

## Part of
Phase 3: Vector Store + SQLite Cache

Closes #25

## Test plan
- [x] ensureCollection skips creation if exists (200)
- [x] ensureCollection creates on 404
- [x] Throws on non-200/non-404 GET status (e.g., 401)
- [x] upsertPoints returns UUIDs and sends correct payload
- [x] Batches large upserts into chunks of 100
- [x] Correct auth headers sent
- [x] deletePoints is no-op for empty array
- [x] searchPoints returns results with scores and payloads
- [x] Error cases throw with descriptive messages