### PR TITLE
feat: semantic search module (search.ts)

### DIFF
--- a/src/lib/search.test.ts
+++ b/src/lib/search.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('../config/env.ts', () => ({
+  default: {
+    EMBEDDING_PROVIDER: 'openai',
+    OPENAI_API_KEY: 'test-key',
+    QDRANT_URL: 'https://test.qdrant.io',
+    QDRANT_KEY: 'test-qdrant-key',
+    NODE_ENV: 'test',
+  },
+}));
+
+import { semanticSearch, readCodeSnippet } from './search.ts';
+
+const MOCK_EMBEDDING_RESPONSE = {
+  data: {
+    data: [{ embedding: Array(1536).fill(0.1), index: 0 }],
+    model: 'text-embedding-3-small',
+    usage: { total_tokens: 5 },
+  },
+};
+
+function mockFetchResponses(...responses: Array<{ data: unknown; status?: number }>) {
+  const spy = vi.spyOn(globalThis, 'fetch');
+  for (const r of responses) {
+    spy.mockResolvedValueOnce(
+      new Response(JSON.stringify(r.data), {
+        status: r.status ?? 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  }
+  return spy;
+}
+
+describe('search', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'search-test-'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('readCodeSnippet', () => {
+    it('reads specific lines from a file', async () => {
+      const filePath = path.join(tmpDir, 'sample.ts');
+      await fs.writeFile(filePath, 'line1\nline2\nline3\nline4\nline5\n');
+
+      const snippet = await readCodeSnippet(filePath, 2, 4);
+
+      expect(snippet).toBe('line2\nline3\nline4');
+    });
+
+    it('returns null for non-existent file', async () => {
+      const snippet = await readCodeSnippet('/nonexistent/file.ts', 1, 5);
+
+      expect(snippet).toBeNull();
+    });
+
+    it('reads from line 1 correctly', async () => {
+      const filePath = path.join(tmpDir, 'first.ts');
+      await fs.writeFile(filePath, 'first\nsecond\nthird\n');
+
+      const snippet = await readCodeSnippet(filePath, 1, 1);
+
+      expect(snippet).toBe('first');
+    });
+  });
+
+  describe('semanticSearch', () => {
+    it('returns results with code snippets', async () => {
+      const filePath = path.join(tmpDir, 'auth.ts');
+      await fs.writeFile(filePath, 'function checkAuth() {\n  return true;\n}\n');
+
+      // Mock: embedQuery response, then searchPoints response
+      mockFetchResponses(MOCK_EMBEDDING_RESPONSE, {
+        data: {
+          result: [
+            {
+              id: 'uuid-1',
+              score: 0.92,
+              payload: {
+                filePath,
+                lineStart: 1,
+                lineEnd: 3,
+                language: 'typescript',
+                chunkHash: 'hash-1',
+              },
+            },
+          ],
+        },
+      });
+
+      const results = await semanticSearch('authentication check');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].score).toBe(0.92);
+      expect(results[0].code).toBe('function checkAuth() {\n  return true;\n}');
+      expect(results[0].filePath).toBe(filePath);
+      expect(results[0].language).toBe('typescript');
+    });
+
+    it('skips results where file was deleted', async () => {
+      mockFetchResponses(MOCK_EMBEDDING_RESPONSE, {
+        data: {
+          result: [
+            {
+              id: 'uuid-1',
+              score: 0.88,
+              payload: {
+                filePath: '/deleted/file.ts',
+                lineStart: 1,
+                lineEnd: 10,
+                language: 'typescript',
+                chunkHash: 'hash-1',
+              },
+            },
+          ],
+        },
+      });
+
+      const results = await semanticSearch('some query');
+
+      expect(results).toHaveLength(0);
+    });
+
+    it('returns empty array when no results found', async () => {
+      mockFetchResponses(MOCK_EMBEDDING_RESPONSE, {
+        data: { result: [] },
+      });
+
+      const results = await semanticSearch('nonexistent thing');
+
+      expect(results).toHaveLength(0);
+    });
+
+    it('passes limit to searchPoints', async () => {
+      const fetchSpy = mockFetchResponses(MOCK_EMBEDDING_RESPONSE, {
+        data: { result: [] },
+      });
+
+      await semanticSearch('test query', 5);
+
+      const searchBody = JSON.parse(fetchSpy.mock.calls[1][1]?.body as string);
+      expect(searchBody.limit).toBe(5);
+    });
+
+    it('returns multiple results sorted by score', async () => {
+      const file1 = path.join(tmpDir, 'a.ts');
+      const file2 = path.join(tmpDir, 'b.ts');
+      await fs.writeFile(file1, 'function a() {}');
+      await fs.writeFile(file2, 'function b() {}');
+
+      mockFetchResponses(MOCK_EMBEDDING_RESPONSE, {
+        data: {
+          result: [
+            {
+              id: 'uuid-1',
+              score: 0.95,
+              payload: {
+                filePath: file1,
+                lineStart: 1,
+                lineEnd: 1,
+                language: 'typescript',
+                chunkHash: 'h1',
+              },
+            },
+            {
+              id: 'uuid-2',
+              score: 0.82,
+              payload: {
+                filePath: file2,
+                lineStart: 1,
+                lineEnd: 1,
+                language: 'typescript',
+                chunkHash: 'h2',
+              },
+            },
+          ],
+        },
+      });
+
+      const results = await semanticSearch('functions');
+
+      expect(results).toHaveLength(2);
+      expect(results[0].score).toBe(0.95);
+      expect(results[1].score).toBe(0.82);
+    });
+  });
+});

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs/promises';
+import { embedQuery } from './embedder.ts';
+import { searchPoints } from './store.ts';
+import { createLogger } from '../utils/logger.ts';
+
+const log = createLogger('search');
+
+const DEFAULT_LIMIT = 10;
+
+interface CodeSearchResult {
+  filePath: string;
+  lineStart: number;
+  lineEnd: number;
+  language: string;
+  score: number;
+  code: string;
+}
+
+async function readCodeSnippet(
+  filePath: string,
+  lineStart: number,
+  lineEnd: number,
+): Promise<string | null> {
+  if (lineStart < 1 || lineEnd < lineStart) {
+    log.warn(`Invalid line range [${lineStart}-${lineEnd}] for ${filePath}`);
+    return null;
+  }
+
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const lines = content.split('\n');
+    return lines.slice(lineStart - 1, lineEnd).join('\n');
+  } catch {
+    return null;
+  }
+}
+
+async function semanticSearch(
+  query: string,
+  limit: number = DEFAULT_LIMIT,
+): Promise<CodeSearchResult[]> {
+  log.info(`Searching for: "${query}" (limit: ${limit})`);
+
+  const queryVector = await embedQuery(query);
+  const qdrantResults = await searchPoints(queryVector, limit);
+
+  if (qdrantResults.length === 0) {
+    log.info('No results found');
+    return [];
+  }
+
+  // Read all code snippets in parallel
+  const snippets = await Promise.all(
+    qdrantResults.map((r) =>
+      readCodeSnippet(r.payload.filePath, r.payload.lineStart, r.payload.lineEnd),
+    ),
+  );
+
+  const results: CodeSearchResult[] = [];
+
+  for (let i = 0; i < qdrantResults.length; i++) {
+    const result = qdrantResults[i];
+    const code = snippets[i];
+
+    if (code === null) {
+      log.warn(`File not found (may have been deleted since indexing): ${result.payload.filePath}`);
+      continue;
+    }
+
+    results.push({
+      filePath: result.payload.filePath,
+      lineStart: result.payload.lineStart,
+      lineEnd: result.payload.lineEnd,
+      language: result.payload.language,
+      score: result.score,
+      code,
+    });
+  }
+
+  log.info(`Found ${results.length} results`);
+  return results;
+}
+
+export { semanticSearch, readCodeSnippet, DEFAULT_LIMIT };
+export type { CodeSearchResult };


### PR DESCRIPTION
## Summary
- Add `src/lib/search.ts` — search orchestrator for semantic code search
- Embeds query via `embedQuery()`, searches Qdrant via `searchPoints()`, reads code from disk
- Parallel file reads via `Promise.all` for performance
- Line range validation guard (rejects corrupt `lineStart < 1` or `lineEnd < lineStart`)
- Gracefully skips results where file was deleted since indexing (warns, doesn't error)
- 8 tests covering: snippet reading, full search flow, deleted files, empty results, limit passing, multi-result ordering

## Part of
Phase 4: Semantic Search

Closes #36

## Test plan
- [x] readCodeSnippet reads specific lines from file
- [x] readCodeSnippet returns null for non-existent file
- [x] readCodeSnippet reads line 1 correctly (off-by-one check)
- [x] semanticSearch returns results with code snippets
- [x] Skips results where file was deleted
- [x] Returns empty array when no Qdrant results
- [x] Passes limit parameter to searchPoints
- [x] Returns multiple results preserving score order